### PR TITLE
Реализация возможности пополнения вендоматов

### DIFF
--- a/Content.Server/VendingMachines/VendingMachineSystem.cs
+++ b/Content.Server/VendingMachines/VendingMachineSystem.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Server.Administration.Logs;
 using System.Numerics;
 using Content.Server.Cargo.Systems;
 using Content.Server.Emp;
@@ -10,16 +11,21 @@ using Content.Shared.Access.Systems;
 using Content.Shared.Actions;
 using Content.Shared.Actions.ActionTypes;
 using Content.Shared.Damage;
+using Content.Shared.Database;
 using Content.Shared.Destructible;
 using Content.Shared.DoAfter;
 using Content.Shared.Emag.Components;
 using Content.Shared.Emag.Systems;
 using Content.Shared.Emp;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
+using Content.Shared.Interaction;
 using Content.Shared.Popups;
 using Content.Shared.Throwing;
 using Content.Shared.VendingMachines;
 using Robust.Server.GameObjects;
 using Robust.Shared.Audio;
+using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Timing;
@@ -36,6 +42,9 @@ namespace Content.Server.VendingMachines
         [Dependency] private readonly ThrowingSystem _throwingSystem = default!;
         [Dependency] private readonly UserInterfaceSystem _userInterfaceSystem = default!;
         [Dependency] private readonly IGameTiming _timing = default!;
+        [Dependency] private readonly SharedContainerSystem _containerSystem = default!;
+        [Dependency] private readonly SharedHandsSystem _handsSystem = default!;
+        [Dependency] private readonly IAdminLogManager _adminLogger = default!;
 
         private ISawmill _sawmill = default!;
 
@@ -53,6 +62,7 @@ namespace Content.Server.VendingMachines
 
             SubscribeLocalEvent<VendingMachineComponent, ActivatableUIOpenAttemptEvent>(OnActivatableUIOpenAttempt);
             SubscribeLocalEvent<VendingMachineComponent, BoundUIOpenedEvent>(OnBoundUIOpened);
+            SubscribeLocalEvent<VendingMachineComponent, AfterInteractUsingEvent>(HandleAfterInteractUsing);
             SubscribeLocalEvent<VendingMachineComponent, VendingMachineEjectMessage>(OnInventoryEjectMessage);
 
             SubscribeLocalEvent<VendingMachineComponent, VendingMachineSelfDispenseEvent>(OnSelfDispense);
@@ -94,7 +104,10 @@ namespace Content.Server.VendingMachines
                 var action = new InstantAction(PrototypeManager.Index<InstantActionPrototype>(component.Action));
                 _action.AddAction(uid, action, uid);
             }
-        }
+			
+			component.Container = _containerSystem.EnsureContainer<Container>(uid, VendingMachineComponent.ContainerId);
+		}
+		
 
         private void OnActivatableUIOpenAttempt(EntityUid uid, VendingMachineComponent component, ActivatableUIOpenAttemptEvent args)
         {
@@ -233,6 +246,73 @@ namespace Content.Server.VendingMachines
             Deny(uid, vendComponent);
             return false;
         }
+		
+		private void HandleAfterInteractUsing(EntityUid uid, VendingMachineComponent component, AfterInteractUsingEvent args)
+        {
+            if (args.Handled || !args.CanReach)
+                return;
+
+            if (!HasComp<HandsComponent>(args.User))
+                return;
+
+            if (!IsAuthorized(uid, args.User, component))
+                return;
+
+            if (!TryInsertItem(uid, args.User, args.Used, component))
+                return;
+
+            _adminLogger.Add(LogType.Action, LogImpact.Medium,
+                $"{ToPrettyString(args.User):player} inserted {ToPrettyString(args.Used)} into {ToPrettyString(uid)}");
+            args.Handled = true;
+        }
+		
+		private bool TryInsertItem(EntityUid vendUid, EntityUid userUid, EntityUid entityUid, VendingMachineComponent vendComponent)
+        {
+            if (!TryGetItemCode(entityUid, out var itemId))
+                return false;
+
+            if (!ItemIsInWhitelist(entityUid, itemId, vendComponent))
+                return false;
+
+            if (!_handsSystem.IsHolding(userUid, entityUid, out var hand) || !_handsSystem.CanDropHeld(userUid, hand))
+                return false;
+
+            if (vendComponent.Ejecting || vendComponent.Broken || !this.IsPowered(vendUid, EntityManager))
+                return false;
+
+            if (!_handsSystem.TryDropIntoContainer(userUid, entityUid, vendComponent.Container))
+                return false;
+
+            if (vendComponent.Inventory.ContainsKey(itemId) &&
+                vendComponent.Inventory.TryGetValue(itemId, out var entry))
+            {
+                entry.Amount++;
+                entry.EntityUids.Add(entityUid);
+				UpdateVendingMachineInterfaceState(vendUid, vendComponent);
+                return true;
+            }
+
+            vendComponent.Inventory.Add(itemId,
+                new VendingMachineInventoryEntry(InventoryType.Regular, itemId, 1, entityUid)
+            );
+			UpdateVendingMachineInterfaceState(vendUid, vendComponent);
+            return true;
+        }
+		
+		private bool ItemIsInWhitelist(EntityUid item, string itemCode, VendingMachineComponent vendComponent)
+        {
+            if (vendComponent.Inventory.ContainsKey(itemCode))
+                return true;
+
+            return vendComponent.Whitelist != null && vendComponent.Whitelist.IsValid(item);
+        }
+		
+		private bool TryGetItemCode(EntityUid entityUid, out string code)
+        {
+            var metadata = IoCManager.Resolve<IEntityManager>().GetComponentOrNull<MetaDataComponent>(entityUid);
+            code = metadata?.EntityPrototype?.ID ?? "";
+            return !string.IsNullOrEmpty(code);
+        }
 
         /// <summary>
         /// Tries to eject the provided item. Will do nothing if the vending machine is incapable of ejecting, already ejecting
@@ -275,7 +355,7 @@ namespace Content.Server.VendingMachines
 
             // Start Ejecting, and prevent users from ordering while anim playing
             vendComponent.Ejecting = true;
-            vendComponent.NextItemToEject = entry.ID;
+            GetItemToEject(ref vendComponent, entry);
             vendComponent.ThrowNextItem = throwItem;
             entry.Amount--;
             UpdateVendingMachineInterfaceState(uid, vendComponent);
@@ -348,7 +428,7 @@ namespace Content.Server.VendingMachines
 
             if (forceEject)
             {
-                vendComponent.NextItemToEject = item.ID;
+                GetItemToEject(ref vendComponent, item);
                 vendComponent.ThrowNextItem = throwItem;
                 var entry = GetEntry(uid, item.ID, item.Type, vendComponent);
                 if (entry != null)
@@ -358,6 +438,19 @@ namespace Content.Server.VendingMachines
             else
             {
                 TryEjectVendorItem(uid, item.Type, item.ID, throwItem, vendComponent);
+            }
+        }
+		
+		private void GetItemToEject(ref VendingMachineComponent vendComponent, VendingMachineInventoryEntry item)
+        {
+            if (item.EntityUids.Count > 0)
+            {
+                vendComponent.NextEntityToEject = item.EntityUids[0];
+                item.EntityUids.RemoveAt(0);
+            }
+            else
+            {
+                vendComponent.NextItemToEject = item.ID;
             }
         }
 
@@ -370,13 +463,26 @@ namespace Content.Server.VendingMachines
             if (!forceEject)
                 TryUpdateVisualState(uid, vendComponent);
 
-            if (string.IsNullOrEmpty(vendComponent.NextItemToEject))
+            if (string.IsNullOrEmpty(vendComponent.NextItemToEject) && vendComponent.NextEntityToEject == null)
             {
                 vendComponent.ThrowNextItem = false;
                 return;
             }
 
-            var ent = Spawn(vendComponent.NextItemToEject, Transform(uid).Coordinates);
+            EntityUid ent;
+
+            if (vendComponent.NextEntityToEject is { } entityUid)
+            {
+                vendComponent.Container.Remove(entityUid);
+                ent = entityUid;
+            }
+            else
+            {
+                ent = Spawn(vendComponent.NextItemToEject, Transform(uid).Coordinates);
+            }
+			
+			
+			
             if (vendComponent.ThrowNextItem)
             {
                 var range = vendComponent.NonLimitedEjectRange;
@@ -384,7 +490,8 @@ namespace Content.Server.VendingMachines
                 _throwingSystem.TryThrow(ent, direction, vendComponent.NonLimitedEjectForce);
             }
 
-            vendComponent.NextItemToEject = null;
+            vendComponent.NextEntityToEject = null;
+			vendComponent.NextItemToEject = null;
             vendComponent.ThrowNextItem = false;
         }
 

--- a/Content.Shared/VendingMachines/VendingMachineComponent.cs
+++ b/Content.Shared/VendingMachines/VendingMachineComponent.cs
@@ -1,6 +1,8 @@
 using Content.Shared.Actions;
 using Content.Shared.Actions.ActionTypes;
+using Content.Shared.Whitelist;
 using Robust.Shared.Audio;
+using Robust.Shared.Containers;
 using Robust.Shared.GameStates;
 using Robust.Shared.Serialization;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
@@ -11,6 +13,8 @@ namespace Content.Shared.VendingMachines
     [RegisterComponent, NetworkedComponent]
     public sealed class VendingMachineComponent : Component
     {
+		public const string ContainerId = "VendingMachine";
+		
         /// <summary>
         /// PrototypeID for the vending machine's inventory, see <see cref="VendingMachineInventoryPrototype"/>
         /// </summary>
@@ -40,13 +44,17 @@ namespace Content.Shared.VendingMachines
 
         [ViewVariables]
         public Dictionary<string, VendingMachineInventoryEntry> ContrabandInventory = new();
-
+		
+		[DataField("whitelist")]
+		public EntityWhitelist? Whitelist;
+		
         public bool Contraband;
 
         public bool Ejecting;
         public bool Denying;
         public bool DispenseOnHitCoolingDown;
-
+		
+		public EntityUid? NextEntityToEject;
         public string? NextItemToEject;
 
         public bool Broken;
@@ -121,7 +129,13 @@ namespace Content.Shared.VendingMachines
         /// </summary>
         [DataField("nextEmpEject", customTypeSerializer: typeof(TimeOffsetSerializer))]
         public TimeSpan NextEmpEject = TimeSpan.Zero;
-
+		
+		/// <summary>
+        ///     All unique entities stored inside
+        /// </summary>
+        [ViewVariables] public Container Container = default!;
+		
+		
         #region Client Visuals
         /// <summary>
         /// RSI state for when the vending machine is unpowered.
@@ -185,11 +199,19 @@ namespace Content.Shared.VendingMachines
         public string ID;
         [ViewVariables(VVAccess.ReadWrite)]
         public uint Amount;
+		[ViewVariables(VVAccess.ReadWrite)]
+        public List<EntityUid> EntityUids = new();
         public VendingMachineInventoryEntry(InventoryType type, string id, uint amount)
         {
             Type = type;
             ID = id;
             Amount = amount;
+        }
+		
+		public VendingMachineInventoryEntry(InventoryType type, string id, uint amount, EntityUid firstUid)
+            : this(type, id, amount)
+        {
+            EntityUids = new List<EntityUid> { firstUid };
         }
     }
 

--- a/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/vending_machines.yml
@@ -883,6 +883,18 @@
     denyState: deny-unshaded
     screenState: normal-unshaded
     loopDeny: false
+    whitelist:
+      components:
+      - Pill
+      - Seed
+      - Produce
+      tags:
+      - Bottle
+      - Ointment
+      - Bloodpack
+      - Brutepack
+      - GlassBeaker
+      - PillCanister
   - type: Advertise
     pack: SmartFridgeAds
   - type: Speech


### PR DESCRIPTION
## Описание PR
Добавляет возможность вручную помещать предметы в торговые автоматы, к которым есть доступ. Предмет должен быть уже в списке продажи. Умные холодильники теперь ограниченно полезны.

## Медиа
![изображение](https://github.com/ss14-ganimed/GS14-Master/assets/94239354/9e27635c-ebdf-42c6-86d4-6bde44f30be6)

## Проверки
- [X] PR полностью завершён и мне не нужна помощь чтобы его закончить.
- [X] Я внимательно просмотрел все свои изменения и багов в них не нашёл.
- [X] Я запускал локальный сервер со своими изменениями и всё протестировал.
- [X] Я добавил скриншот/видео демонстрации PR в игре, **или** этот PR этого не требует. 

## Изменения
:cl: temporaldarkness
- tweak: Модификация для торговых автоматов теперь позволяет загружать новый ассортимент внутрь!
